### PR TITLE
Adds http-server tag and exports gce_zone

### DIFF
--- a/ansible/gce_prov_playbook.yml
+++ b/ansible/gce_prov_playbook.yml
@@ -14,7 +14,7 @@
         zone: "{{ gce_zone }}"
         machine_type: "{{ gce_machine_type }}"
         image: "{{ gce_image }}"
-        tags: "{{ gce_tag_Role }}"
+        tags: ["{{ gce_tag_Role }}", "http-server"]
         num_instances: "{{ gce_count }}"
         disk_size: "{{ gce_volume_size }}"
         service_account_email: "{{ GCE_EMAIL }}"
@@ -40,6 +40,5 @@
     # update shippable resource state
     - name: run cmd
       shell: |
-        shipctl put_resource_state_multi "{{ STATE_RES_NAME }}" "INST_{{ item.0 }}_PUBLIC_IP={{ item.1.public_ip }}" "gce_tag_Role={{ gce_tag_Role }}" "gce_name={{ gce_name }}"
+        shipctl put_resource_state_multi "{{ STATE_RES_NAME }}" "INST_{{ item.0 }}_PUBLIC_IP={{ item.1.public_ip }}" "gce_tag_Role={{ gce_tag_Role }}" "gce_name={{ gce_name }}" "gce_zone={{ gce_zone }}"
       with_indexed_items: "{{ gce.instance_data }}"
-


### PR DESCRIPTION
https://github.com/devops-recipes/prov_gcp_gce_ansible/issues/1

Adding `http-server` tag for allowing the GCE instance to be used as http server by exposing the port 80.
We are also exporting `gce_zone` for use in the downstream jobs like `install_gce_nexus`